### PR TITLE
[#558] gce peering

### DIFF
--- a/pipelines/gcp-create-cluster.Jenkinsfile
+++ b/pipelines/gcp-create-cluster.Jenkinsfile
@@ -28,6 +28,13 @@ pipeline {
                     legion.getWanIp()
                     legion.buildDescription()
                 }
+                sshagent(["${env.legionProfilesGitlabKey}"]) {
+                    sh"""
+                      ssh-keyscan git.epam.com >> ~/.ssh/known_hosts
+                      git clone ${env.param_legion_cicd_repo} legion-cicd
+                      cd legion-cicd && git checkout ${env.param_legion_cicd_branch}
+                    """
+                }
             }
         }
 

--- a/pipelines/gcp-create-cluster.Jenkinsfile
+++ b/pipelines/gcp-create-cluster.Jenkinsfile
@@ -11,6 +11,9 @@ pipeline {
         param_helm_repo = "${params.HelmRepo}"
         param_gcp_project = "${params.GcpProject}"
         param_gcp_zone = "${params.GcpZone}"
+        legionCicdGitlabKey = "legion-profiles-gitlab-key"
+        param_legion_cicd_repo = "${params.CicdRepoGitUrl}"
+        param_legion_cicd_branch = "${params.CicdRepoGitBranch}"
         //Job parameters
         gcpCredential = "gcp-epmd-legn-legion-automation"
         sharedLibPath = "pipelines/legionPipeline.groovy"
@@ -28,7 +31,7 @@ pipeline {
                     legion.getWanIp()
                     legion.buildDescription()
                 }
-                sshagent(["${env.legionProfilesGitlabKey}"]) {
+                sshagent(["${env.legionCicdGitlabKey}"]) {
                     sh"""
                       ssh-keyscan git.epam.com >> ~/.ssh/known_hosts
                       git clone ${env.param_legion_cicd_repo} legion-cicd

--- a/pipelines/gcp-destroy-cluster.Jenkinsfile
+++ b/pipelines/gcp-destroy-cluster.Jenkinsfile
@@ -11,6 +11,9 @@ pipeline {
         param_helm_repo = "${params.HelmRepo}"
         param_gcp_project = "${params.GcpProject}"
         param_gcp_zone = "${params.GcpZone}"
+        legionCicdGitlabKey = "legion-profiles-gitlab-key"
+        param_legion_cicd_repo = "${params.CicdRepoGitUrl}"
+        param_legion_cicd_branch = "${params.CicdRepoGitBranch}"
         //Job parameters
         gcpCredential = "gcp-epmd-legn-legion-automation"
         sharedLibPath = "pipelines/legionPipeline.groovy"
@@ -27,6 +30,13 @@ pipeline {
                     legion = load "${env.sharedLibPath}"
                     legion.getWanIp()
                     legion.buildDescription()
+                }
+                sshagent(["${env.legionCicdGitlabKey}"]) {
+                    sh"""
+                      ssh-keyscan git.epam.com >> ~/.ssh/known_hosts
+                      git clone ${env.param_legion_cicd_repo} legion-cicd
+                      cd legion-cicd && git checkout ${env.param_legion_cicd_branch}
+                    """
                 }
             }
         }

--- a/pipelines/legionPipeline.groovy
+++ b/pipelines/legionPipeline.groovy
@@ -618,13 +618,14 @@ def terraformRun(command, tfModule, extraVars='', workPath="${terraformHome}/env
 }
 
 def terraformOutput(command, tfModule, params = '-json', workPath="${terraformHome}/env_types/${env.param_cluster_type}/${tfModule}/", backendConfigBucket="bucket=${env.param_cluster_name}-tfstate") {
+    sh """
+        cd ${workPath}
+        export TF_DATA_DIR=/tmp/.terraform-${env.param_cluster_name}-${tfModule}
+        terraform init -backend-config="${backendConfigBucket}"
+    """
     sh returnStdout:true, script: """ #!/bin/bash -xe
         cd ${workPath}
-
         export TF_DATA_DIR=/tmp/.terraform-${env.param_cluster_name}-${tfModule}
-        
-        terraform init -backend-config="${backendConfigBucket}"
-        
         terraform output ${params}
     """
 }

--- a/pipelines/legionPipeline.groovy
+++ b/pipelines/legionPipeline.groovy
@@ -80,7 +80,7 @@ def createGCPCluster() {
                         }
                         stage('Add infra private DNS zone resolving') {
                             script {
-                               NETWORK_TO_ADD = terraformOutput("output", "gke_create", "-json network_name").trim()
+                               NETWORK_TO_ADD = terraformOutput("gke_create", "-json network_name").trim()
                             }
                             sh '''
                                chmod 600 ~/.ssh/id_rsa
@@ -617,7 +617,7 @@ def terraformRun(command, tfModule, extraVars='', workPath="${terraformHome}/env
     """
 }
 
-def terraformOutput(command, tfModule, params = '-json', workPath="${terraformHome}/env_types/${env.param_cluster_type}/${tfModule}/", backendConfigBucket="bucket=${env.param_cluster_name}-tfstate") {
+def terraformOutput(tfModule, params = '-json', workPath="${terraformHome}/env_types/${env.param_cluster_type}/${tfModule}/", backendConfigBucket="bucket=${env.param_cluster_name}-tfstate") {
     sh """
         cd ${workPath}
         export TF_DATA_DIR=/tmp/.terraform-${env.param_cluster_name}-${tfModule}

--- a/pipelines/legionPipeline.groovy
+++ b/pipelines/legionPipeline.groovy
@@ -218,7 +218,7 @@ def destroyGcpCluster() {
                                 terraformRun("destroy", "k8s_setup")
                                 terraformRun("destroy", "helm_init")
                                 script {
-                                   NETWORK_TO_REMOVE = terraformRun("output", "gke_create", "-json network_name").trim()
+                                   NETWORK_TO_REMOVE = terraformOutput("gke_create", "-json network_name").trim()
                                 }
                                 sh '''
                                    chmod 600 ~/.ssh/id_rsa

--- a/terraform/env_types/gcp/gke/gke_create/main.tf
+++ b/terraform/env_types/gcp/gke/gke_create/main.tf
@@ -39,6 +39,16 @@ module "vpc_peering" {
   aws_route_table_id   = var.aws_route_table_id
 }
 
+module "vpc_peering_gce" {
+  source                      = "../../../../modules/gcp/networking/vpc_peering_gce"
+  project_id                  = var.project_id
+  region                      = var.region
+  zone                        = var.zone
+  gcp_network_1_name          = module.vpc.network_name
+  gcp_network_1_range         = [var.gcp_cidr]
+  gcp_network_2_name          = var.infra_vpc_name
+  gcp_network_2_range         = [var.infra_cidr]
+}
 ########################################################
 # IAM
 ########################################################

--- a/terraform/env_types/gcp/gke/gke_create/main.tf
+++ b/terraform/env_types/gcp/gke/gke_create/main.tf
@@ -75,6 +75,7 @@ module "gke_cluster" {
   allowed_ips           = var.allowed_ips
   agent_cidr            = var.agent_cidr
   nodes_sa              = module.iam.service_account
+  cluster_ipv4_cidr     = var.pods_cidr
   gke_node_machine_type = var.gke_node_machine_type
   location              = var.location
   network               = module.vpc.network_name

--- a/terraform/env_types/gcp/gke/gke_create/main.tf
+++ b/terraform/env_types/gcp/gke/gke_create/main.tf
@@ -23,14 +23,20 @@ module "firewall" {
 }
 
 module "vpc_peering" {
-  source                      = "../../../../modules/gcp/networking/vpc_peering_gce"
-  project_id                  = var.project_id
-  region                      = var.region
-  zone                        = var.zone
-  gcp_network_1_name          = module.vpc.network_name
-  gcp_network_1_range         = [var.gcp_cidr]
-  gcp_network_2_name          = var.infra_vpc_name
-  gcp_network_2_range         = [var.infra_cidr]
+  source               = "../../../../modules/gcp/networking/vpc_peering"
+  project_id           = var.project_id
+  region               = var.region
+  zone                 = var.zone
+  cluster_name         = var.cluster_name
+  region_aws           = var.region_aws
+  aws_profile          = var.aws_profile
+  aws_credentials_file = var.aws_credentials_file
+  aws_vpc_id           = var.aws_vpc_id
+  gcp_cidr             = var.gcp_cidr
+  aws_sg               = var.aws_sg
+  aws_cidr             = var.aws_cidr
+  gcp_network          = module.vpc.network_name
+  aws_route_table_id   = var.aws_route_table_id
 }
 
 ########################################################

--- a/terraform/env_types/gcp/gke/gke_create/main.tf
+++ b/terraform/env_types/gcp/gke/gke_create/main.tf
@@ -45,7 +45,7 @@ module "vpc_peering_gce" {
   region                      = var.region
   zone                        = var.zone
   gcp_network_1_name          = module.vpc.network_name
-  gcp_network_1_range         = [var.gcp_cidr]
+  gcp_network_1_range         = [var.gcp_cidr, var.pods_cidr]
   gcp_network_2_name          = var.infra_vpc_name
   gcp_network_2_range         = [var.infra_cidr]
 }

--- a/terraform/env_types/gcp/gke/gke_create/main.tf
+++ b/terraform/env_types/gcp/gke/gke_create/main.tf
@@ -23,20 +23,14 @@ module "firewall" {
 }
 
 module "vpc_peering" {
-  source               = "../../../../modules/gcp/networking/vpc_peering"
-  project_id           = var.project_id
-  region               = var.region
-  zone                 = var.zone
-  cluster_name         = var.cluster_name
-  region_aws           = var.region_aws
-  aws_profile          = var.aws_profile
-  aws_credentials_file = var.aws_credentials_file
-  aws_vpc_id           = var.aws_vpc_id
-  gcp_cidr             = var.gcp_cidr
-  aws_sg               = var.aws_sg
-  aws_cidr             = var.aws_cidr
-  gcp_network          = module.vpc.network_name
-  aws_route_table_id   = var.aws_route_table_id
+  source                      = "../../../../modules/gcp/networking/vpc_peering_gce"
+  project_id                  = var.project_id
+  region                      = var.region
+  zone                        = var.zone
+  gcp_network_1_name          = module.vpc.network_name
+  gcp_network_1_range         = [var.gcp_cidr]
+  gcp_network_2_name          = var.infra_vpc_name
+  gcp_network_2_range         = [var.infra_cidr]
 }
 
 ########################################################
@@ -77,4 +71,3 @@ module "gke_cluster" {
   bastion_tag           = var.bastion_tag
   gke_node_tag          = var.gke_node_tag
 }
-

--- a/terraform/env_types/gcp/gke/gke_create/outputs.tf
+++ b/terraform/env_types/gcp/gke/gke_create/outputs.tf
@@ -9,5 +9,5 @@
 #   value = "${module.gke_cluster.bastion_address}"
 # }
 output network_name {
-  value = module.gke_cluster.vpc.network_name
+  value = module.vpc.network_name
 }

--- a/terraform/env_types/gcp/gke/gke_create/outputs.tf
+++ b/terraform/env_types/gcp/gke/gke_create/outputs.tf
@@ -8,6 +8,6 @@
 # output bastion_address {
 #   value = "${module.gke_cluster.bastion_address}"
 # }
-# output k8s_api_address {
-#   value = "${module.gke_cluster.k8s_api_address}"
-# }
+output network_name {
+  value = module.gke_cluster.vpc.network_name
+}

--- a/terraform/env_types/gcp/gke/gke_create/variables.tf
+++ b/terraform/env_types/gcp/gke/gke_create/variables.tf
@@ -65,6 +65,10 @@ variable "gcp_cidr" {
   description = "GCP network CIDR"
 }
 
+variable "pods_cidr" {
+  description = "GKE pods CIDR"
+}
+
 variable "aws_sg" {
   description = "AWS SG id for gcp access"
 }

--- a/terraform/env_types/gcp/gke/gke_create/variables.tf
+++ b/terraform/env_types/gcp/gke/gke_create/variables.tf
@@ -39,6 +39,11 @@ variable "infra_zone_name" {
   description = "Region of resources"
 }
 
+variable "infra_cidr" {
+  default     = ""
+  description = "GCP infra network CIDR"
+}
+
 variable "region_aws" {
   default     = "us-east-2"
   description = "Region of AWS resources"
@@ -58,10 +63,6 @@ variable "aws_vpc_id" {
 
 variable "gcp_cidr" {
   description = "GCP network CIDR"
-}
-
-variable "infra_cidr" {
-  description = "GCP infra network CIDR"
 }
 
 variable "aws_sg" {

--- a/terraform/env_types/gcp/gke/gke_create/variables.tf
+++ b/terraform/env_types/gcp/gke/gke_create/variables.tf
@@ -29,6 +29,16 @@ variable "region" {
   description = "Region of resources"
 }
 
+variable "infra_vpc_name" {
+  default = "infra-vpc"
+  description = "Region of resources"
+}
+
+variable "infra_zone_name" {
+  default = "ailifecycle-org-private"
+  description = "Region of resources"
+}
+
 variable "region_aws" {
   default     = "us-east-2"
   description = "Region of AWS resources"
@@ -48,6 +58,10 @@ variable "aws_vpc_id" {
 
 variable "gcp_cidr" {
   description = "GCP network CIDR"
+}
+
+variable "infra_cidr" {
+  description = "GCP infra network CIDR"
 }
 
 variable "aws_sg" {
@@ -140,4 +154,3 @@ variable "bastion_hostname" {
   default     = "bastion"
   description = "bastion hpstname"
 }
-

--- a/terraform/modules/gcp/gke_cluster/main.tf
+++ b/terraform/modules/gcp/gke_cluster/main.tf
@@ -23,6 +23,7 @@ resource "google_container_cluster" "cluster" {
   network            = var.network
   subnetwork         = var.subnetwork
   min_master_version = var.k8s_version
+  cluster_ipv4_cidr  = var.cluster_ipv4_cidr
 
   # We can't create a cluster with no node pool defined, but we want to only use
   # separately managed node pools. So we create the smallest possible default

--- a/terraform/modules/gcp/gke_cluster/variables.tf
+++ b/terraform/modules/gcp/gke_cluster/variables.tf
@@ -105,6 +105,11 @@ variable "master_ipv4_cidr_block" {
   description = "GKE master CIDR"
 }
 
+variable "cluster_ipv4_cidr" {
+  default     = "10.40.0.0/14"
+  description = "GKE pods CIDR"
+}
+
 #############
 # Node pool
 #############

--- a/terraform/modules/gcp/gke_cluster/variables.tf
+++ b/terraform/modules/gcp/gke_cluster/variables.tf
@@ -106,7 +106,7 @@ variable "master_ipv4_cidr_block" {
 }
 
 variable "cluster_ipv4_cidr" {
-  default     = "10.40.0.0/14"
+  default     = ""
   description = "GKE pods CIDR"
 }
 

--- a/terraform/modules/gcp/networking/vpc_peering_gce/README.md
+++ b/terraform/modules/gcp/networking/vpc_peering_gce/README.md
@@ -1,0 +1,14 @@
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| cluster\_name | Legion cluster name | string | `"legion"` | no |
+| gcp\_network\_1\_name | VPC Network name to peer with at GCP | string | n/a | yes |
+| gcp\_network\_1\_range | VPC Network name to peer with at GCP | list | n/a | yes |
+| gcp\_network\_2\_name | VPC Network name to peer with at GCP | string | n/a | yes |
+| gcp\_network\_2\_range | VPC Network name to peer with at GCP | list | n/a | yes |
+| infra\_zone\_name | VPC Network name to peer with at GCP | string | n/a | yes |
+| project\_id | Target project id | string | n/a | yes |
+| region | Region of resources | string | n/a | yes |
+| zone | Default zone | string | n/a | yes |
+

--- a/terraform/modules/gcp/networking/vpc_peering_gce/main.tf
+++ b/terraform/modules/gcp/networking/vpc_peering_gce/main.tf
@@ -1,30 +1,30 @@
 data "google_compute_network" "gcp_network_1" {
-  project = "${var.project_id}"
-  name    = "${var.gcp_network_1_name}"
+  project = var.project_id
+  name    = var.gcp_network_1_name
 }
 
 data "google_compute_network" "gcp_network_2" {
-  project = "${var.project_id}"
-  name    = "${var.gcp_network_2_name}"
+  project = var.project_id
+  name    = var.gcp_network_2_name
 }
 
 resource "google_compute_network_peering" "peering1" {
   name         = "${data.google_compute_network.gcp_network_2.name}-${data.google_compute_network.gcp_network_1.name}-peering"
-  network      = "${data.google_compute_network.gcp_network_1.self_link}"
-  peer_network = "${data.google_compute_network.gcp_network_2.self_link}"
+  network      = data.google_compute_network.gcp_network_1.self_link
+  peer_network = data.google_compute_network.gcp_network_2.self_link
 }
 
 resource "google_compute_network_peering" "peering2" {
   name         = "${data.google_compute_network.gcp_network_1.name}-${data.google_compute_network.gcp_network_2.name}-peering"
-  network      = "${data.google_compute_network.gcp_network_2.self_link}"
-  peer_network = "${data.google_compute_network.gcp_network_1.self_link}"
+  network      = data.google_compute_network.gcp_network_2.self_link
+  peer_network = data.google_compute_network.gcp_network_1.self_link
 }
 
 resource "google_compute_firewall" "to_network_1" {
-  project       = "${var.project_id}"
+  project       = var.project_id
   name          = "${data.google_compute_network.gcp_network_2.name}-${data.google_compute_network.gcp_network_1.name}"
-  network       = "${data.google_compute_network.gcp_network_2.name}"
-  source_ranges = "${var.gcp_network_1_range}"
+  network       = data.google_compute_network.gcp_network_2.name
+  source_ranges = var.gcp_network_1_range
 
   allow {
     protocol = "icmp"
@@ -40,10 +40,10 @@ resource "google_compute_firewall" "to_network_1" {
 }
 
 resource "google_compute_firewall" "to_network_2" {
-  project       = "${var.project_id}"
+  project       = var.project_id
   name          = "${data.google_compute_network.gcp_network_1.name}-${data.google_compute_network.gcp_network_2.name}"
-  network       = "${data.google_compute_network.gcp_network_1.name}"
-  source_ranges = "${var.gcp_network_2_range}"
+  network       = data.google_compute_network.gcp_network_1.name
+  source_ranges = var.gcp_network_2_range
 
   allow {
     protocol = "icmp"
@@ -57,3 +57,4 @@ resource "google_compute_firewall" "to_network_2" {
     protocol = "udp"
   }
 }
+

--- a/terraform/modules/gcp/networking/vpc_peering_gce/main.tf
+++ b/terraform/modules/gcp/networking/vpc_peering_gce/main.tf
@@ -1,0 +1,59 @@
+data "google_compute_network" "gcp_network_1" {
+  project = "${var.project_id}"
+  name    = "${var.gcp_network_1_name}"
+}
+
+data "google_compute_network" "gcp_network_2" {
+  project = "${var.project_id}"
+  name    = "${var.gcp_network_2_name}"
+}
+
+resource "google_compute_network_peering" "peering1" {
+  name         = "${data.google_compute_network.gcp_network_2.name}-${data.google_compute_network.gcp_network_1.name}-peering"
+  network      = "${data.google_compute_network.gcp_network_1.self_link}"
+  peer_network = "${data.google_compute_network.gcp_network_2.self_link}"
+}
+
+resource "google_compute_network_peering" "peering2" {
+  name         = "${data.google_compute_network.gcp_network_1.name}-${data.google_compute_network.gcp_network_2.name}-peering"
+  network      = "${data.google_compute_network.gcp_network_2.self_link}"
+  peer_network = "${data.google_compute_network.gcp_network_1.self_link}"
+}
+
+resource "google_compute_firewall" "to_network_1" {
+  project       = "${var.project_id}"
+  name          = "${data.google_compute_network.gcp_network_2.name}-${data.google_compute_network.gcp_network_1.name}"
+  network       = "${data.google_compute_network.gcp_network_2.name}"
+  source_ranges = "${var.gcp_network_1_range}"
+
+  allow {
+    protocol = "icmp"
+  }
+
+  allow {
+    protocol = "tcp"
+  }
+
+  allow {
+    protocol = "udp"
+  }
+}
+
+resource "google_compute_firewall" "to_network_2" {
+  project       = "${var.project_id}"
+  name          = "${data.google_compute_network.gcp_network_1.name}-${data.google_compute_network.gcp_network_2.name}"
+  network       = "${data.google_compute_network.gcp_network_1.name}"
+  source_ranges = "${var.gcp_network_2_range}"
+
+  allow {
+    protocol = "icmp"
+  }
+
+  allow {
+    protocol = "tcp"
+  }
+
+  allow {
+    protocol = "udp"
+  }
+}

--- a/terraform/modules/gcp/networking/vpc_peering_gce/variables.tf
+++ b/terraform/modules/gcp/networking/vpc_peering_gce/variables.tf
@@ -1,0 +1,29 @@
+variable "project_id" {
+  description = "Target project id"
+}
+
+variable "zone" {
+  description = "Default zone"
+}
+
+variable "region" {
+  description = "Region of resources"
+}
+
+variable "gcp_network_1_name" {
+  description = "VPC Network 1 name to peer with"
+}
+
+variable "gcp_network_1_range" {
+  type        = "list"
+  description = "VPC Network 1 range to allow"
+}
+
+variable "gcp_network_2_name" {
+  description = "VPC Network 2 name to peer with"
+}
+
+variable "gcp_network_2_range" {
+  type        = "list"
+  description = "VPC Network 2 range to allow"
+}

--- a/terraform/modules/gcp/networking/vpc_peering_gce/variables.tf
+++ b/terraform/modules/gcp/networking/vpc_peering_gce/variables.tf
@@ -15,7 +15,7 @@ variable "gcp_network_1_name" {
 }
 
 variable "gcp_network_1_range" {
-  type        = "list"
+  type        = list(string)
   description = "VPC Network 1 range to allow"
 }
 
@@ -24,6 +24,7 @@ variable "gcp_network_2_name" {
 }
 
 variable "gcp_network_2_range" {
-  type        = "list"
+  type        = list(string)
   description = "VPC Network 2 range to allow"
 }
+

--- a/terraform/modules/gcp/networking/vpc_peering_gce/versions.tf
+++ b/terraform/modules/gcp/networking/vpc_peering_gce/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
- Added vpc gcp to gcp peering module

Update notes:
- secrets should be updated with new parameters:
  `infra_vpc_name`
  `infra_cidr`

- New pipeline step should be added when creating new GKE cluster:
`  GOOGLE_CREDENTIALS={CREDENTIALS_PATH} terraform apply -var="networks_to_add=${VPC_SELF_LINK_TO_ADD}" -var="current_networks=$(terraform output -json visibility_networks)" -var-file={PROFILE_PATH} legion-cicd/terraform/modules/dns`

- New pipeline step should be added when destroying GKE cluster:
`  GOOGLE_CREDENTIALS={CREDENTIALS_PATH} terraform apply -var="networks_to_remove=${VPC_SELF_LINK_TO_REMOVE}" -var="current_networks=$(terraform output -json visibility_networks)" -var-file={PROFILE_PATH} legion-cicd/terraform/modules/dns`

