### PR TITLE
[#989] Fix GKE service subnets collision

### DIFF
--- a/terraform/env_types/gcp/gke/gke_create/main.tf
+++ b/terraform/env_types/gcp/gke/gke_create/main.tf
@@ -59,6 +59,7 @@ module "gke_cluster" {
   agent_cidr           = var.agent_cidr
   nodes_sa             = module.iam.service_account
   pods_cidr            = var.pods_cidr
+  service_cidr          = var.service_cidr
   location             = var.location
   node_locations       = var.node_locations
   initial_node_count   = var.initial_node_count

--- a/terraform/env_types/gcp/gke/gke_create/variables.tf
+++ b/terraform/env_types/gcp/gke/gke_create/variables.tf
@@ -64,6 +64,10 @@ variable "pods_cidr" {
   description = "GKE pods CIDR"
 }
 
+variable "service_cidr" {
+  description = "GKE service CIDR"
+}
+
 variable "aws_sg" {
   description = "AWS SG id for gcp access"
 }

--- a/terraform/modules/gcp/gke_cluster/main.tf
+++ b/terraform/modules/gcp/gke_cluster/main.tf
@@ -85,8 +85,9 @@ resource "google_container_cluster" "cluster" {
   }
 
   ip_allocation_policy {
-    use_ip_aliases          = true
-    cluster_ipv4_cidr_block = var.pods_cidr
+    use_ip_aliases           = true
+    cluster_ipv4_cidr_block  = var.pods_cidr
+    services_ipv4_cidr_block = var.service_cidr
   }
 
   addons_config {

--- a/terraform/modules/gcp/gke_cluster/variables.tf
+++ b/terraform/modules/gcp/gke_cluster/variables.tf
@@ -120,6 +120,10 @@ variable "pods_cidr" {
   description = "GKE pods CIDR"
 }
 
+variable "service_cidr" {
+  description = "GKE service CIDR"
+}
+
 #############
 # Node pool
 #############

--- a/vars_template.yaml
+++ b/vars_template.yaml
@@ -16,6 +16,7 @@ bastion_tag: str                # Bastion host network tag
 gke_node_tag: str               # GKE cluster node's network tag
 infra_cidr: str                 # Core infrastructure resources CIDR
 pods_cidr: str                  # Cluster PODs CIDR
+service_cidr: str               # Cluster Services CIDR
 cloud_type: str                 # Target hosting cloud
 k8s_version: str                # Kubernetes master version
 node_version: str               # Kubernetes node version


### PR DESCRIPTION
Add `service_cidr` variable (must be part of VPC subnet) and use it to define GKE services CIDR to avoid subnet collisions.    

NOTE: there is also appropriate legion-profiles PR!