### PR TITLE
[#47] Separate TLS/SSH data receiving from base modules

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -8,10 +8,10 @@ For more details and technical documentation see the Legion project repository h
 Prerequisites:
  For each of the clusters you need to have have the next preconfigured items:
  - GCS Bucket for terraform state with name equal to "<CLUSTER_NAME>-tfstate"
- - SSL certs stored at S3 Bucket (path is configured in vars file)
- - SSH key stored at S3 Bucket (path is configured in vars file)
+ - Create `cluster_profile.json` file with terraform variables (should be specified for each terraform run as a -var-file argument)
+ - SSL certificate and private key should be defined as `tls_crt` and `tls_key` variables in `cluster_profile.json`
+ - SSH public key should be defined as `ssh_key` variable in `cluster_profile.json`
  - Reserve Static IP "<CLUSTER_NAME>-nat-gw" and add this IP to Oauth provider (Keycloak for example)
- - cluster_profile.json file with terraform variables (should be specified for each terraform run as a -var-file argument)
 
 In order to setup legion cluster at GCP with provided modules you have to trigger terraform for each of the Legion infrastructure layer.
 The order of infrastructure components provisioning is the next:
@@ -23,38 +23,50 @@ GKE cluster:
 EKS cluster:
  - TBC
 
-Terraform modules for each of the layer could be applied by running the set of command below from the corresponding module directory:
+Terraform modules for each of the layer could be applied by running the set of commands below from the corresponding module directory:
 ### TERRAFORM INIT
-CLUSTER_NAME=<CLUSTER_NAME_HERE> TF_DATA_DIR=/tmp/.terraform_${CLUSTER_NAME}_$(basename "$PWD") bash -c  'terraform init -backend-config="bucket=${CLUSTER_NAME}-tfstate"'
+
+```bash
+CLUSTER_NAME=<CLUSTER_NAME_HERE> TF_DATA_DIR=/tmp/.terraform_${CLUSTER_NAME}_${PWD##*/} bash -c 'terraform init -backend-config="bucket=${CLUSTER_NAME}-tfstate"'
+```
+
 ### TERRAFORM PLAN
-CLUSTER_NAME=<CLUSTER_NAME_HERE> TF_DATA_DIR=/tmp/.terraform_${CLUSTER_NAME}_$(basename "$PWD") bash -c  'terraform plan \
+
+```bash
+CLUSTER_NAME=<CLUSTER_NAME_HERE> TF_DATA_DIR=/tmp/.terraform_${CLUSTER_NAME}_${PWD##*/} bash -c 'terraform plan \
 -var-file=/PATH/TO/VARIABLES.json \
 -var="agent_cidr=<YOUR_IP_HERE>/32"'
+```
+
 ### TERRAFORM APPLY
-CLUSTER_NAME=<CLUSTER_NAME_HERE> TF_DATA_DIR=/tmp/.terraform_${CLUSTER_NAME}_$(basename "$PWD") bash -c  'terraform apply \
+
+```bash
+CLUSTER_NAME=<CLUSTER_NAME_HERE> TF_DATA_DIR=/tmp/.terraform_${CLUSTER_NAME}_${PWD##*/} bash -c 'terraform apply \
 -var-file=/PATH/TO/VARIABLES.json \
 -var="agent_cidr=<YOUR_IP_HERE>/32"'
+```
 
 There is also a helper script which allows you to create fully configured Legion cluster with a single command.
 The easiest way to run the script is to use prebuilt docker image containing all required components.
-You should pass cluster_profile.json file with all parameters required for cluster setup (refer to vars_template.yaml for details) and appropriate credentials for cloud operations (e.g GOOGLE_CREDENTIALS, AWS_ACCESS_KEY, etc.).
+You should pass cluster_profile.json file with all parameters required for cluster setup (refer to vars_template.yaml for details) and appropriate credentials for cloud operations (e.g `GOOGLE_CREDENTIALS`, `AWS_ACCESS_KEY`, etc.).
 Here is the example of command which mounts all dependencies to the docker container and triggers a cluster creation:
 
-docker run -v <local_path_to_cluster_profile.json>:/tmp/cluster_profile.json -v <path_to_local_gcp_credentials_file.json>/:/tmp/gcp_credentials_file.json -v $HOME/.aws:/root/.aws -e PROFILE=/tmp/cluster_profile.json -e GOOGLE_CREDENTIALS=/tmp/gcp_credentials_file.json k8s-terraform:latest tf_runner create
+```bash
+docker run -v <local_path_to_cluster_profile.json>:/tmp/cluster_profile.json -v <path_to_local_gcp_credentials_file.json>/:/tmp/gcp_credentials_file.json -e PROFILE=/tmp/cluster_profile.json -e GOOGLE_CREDENTIALS=/tmp/gcp_credentials_file.json k8s-terraform:latest tf_runner create
+```
 
-Mandatory parameters are PROFILE and GOOGLE_CREDENTIALS environment variables which point to the mounted files required for cluster provisioning.
-The same way tf_runner script could be executed locally if you have all dependencies available.
+Mandatory parameters are `PROFILE` and `GOOGLE_CREDENTIALS` environment variables which point to the mounted files required for cluster provisioning.
+The same way [`tf_runner`](tools/tf_runner.sh) script could be executed locally if you have all dependencies available.
 
 ## Cluster profile preparation
 In order to setup Legion cluster with all components you should have cluster profile with all parameters required for platform setup.
-The file should be provided as a json file to terraform modules with -var-file argument. All required variables with their purposes 
-could be find in vars_template.yaml file in this repository. 
-You may want to create cluster profile manually or use hiera_exporter helper script to pull the data from hiera data storage.
+The file should be provided as a json file to terraform modules with -var-file argument. All required variables with their purposes could be find in [`vars_template.yaml`](vars_template.yaml) file in this repository.
+You may want to create cluster profile manually or use [`hiera_exporter`](tools/hiera_exporter) helper script to pull the data from hiera data storage.
 
 # Hiera data export
 Hiera allows you to store hierarchical data in yaml format and request required data structures matching request filters.
 For Legion CI/CD purposes we use separate profiles repository (as you may want to do as well) with yaml files describing clusters setup.
-Place private_key.pkcs7.pem and public_key.pkcs7.pem keys to expected location (/etc/puppetlabs/puppet/eyaml/ by default) and trigger hiera_exporter script from hieradata directory with proper arguments.
+Place `private_key.pkcs7.pem` and `public_key.pkcs7.pem` keys to expected location (`/etc/puppetlabs/puppet/eyaml/` by default) and trigger [`hiera_exporter`](tools/hiera_exporter) script from hieradata directory with proper arguments.
 This will generate Terraform compatible variables json file which should be used with Terraform modules for clusters setup.
 
 

--- a/pipelines/legionPipeline.groovy
+++ b/pipelines/legionPipeline.groovy
@@ -13,7 +13,6 @@ def createGCPCluster() {
         file(credentialsId: "${env.hieraPrivatePKCSKey}", variable: 'PrivatePkcsKey')]) {
             withCredentials([
             file(credentialsId: "${env.hieraPublicPKCSKey}", variable: 'PublicPkcsKey')]) {
-                withAWS(credentials: 'kops') {
                     wrap([$class: 'AnsiColorBuildWrapper', colorMapName: "xterm"]) {
                         docker.image("${env.param_docker_repo}/k8s-terraform:${env.param_legion_infra_version}").inside("-e GOOGLE_CREDENTIALS=${gcpCredential} -e PROFILE=${env.clusterProfile} -u root") {
                             stage('Extract Hiera data') {
@@ -38,7 +37,6 @@ def createGCPCluster() {
                             }
                         }
                     }
-                }
             }
         }
     }
@@ -51,7 +49,6 @@ def destroyGcpCluster() {
         file(credentialsId: "${env.hieraPrivatePKCSKey}", variable: 'PrivatePkcsKey')]) {
             withCredentials([
             file(credentialsId: "${env.hieraPublicPKCSKey}", variable: 'PublicPkcsKey')]) {
-                withAWS(credentials: 'kops') {
                     wrap([$class: 'AnsiColorBuildWrapper', colorMapName: "xterm"]) {
                         docker.image("${env.param_docker_repo}/k8s-terraform:${env.param_legion_infra_version}").inside("-e GOOGLE_CREDENTIALS=${gcpCredential} -e PROFILE=${env.clusterProfile} -u root") {
                             stage('Extract Hiera data') {
@@ -75,7 +72,6 @@ def destroyGcpCluster() {
                             }
                         }
                     }
-                }
             }
         }
     }

--- a/terraform/env_types/gcp/gke/gke_create/main.tf
+++ b/terraform/env_types/gcp/gke/gke_create/main.tf
@@ -53,9 +53,6 @@ module "gke_cluster" {
   cluster_name         = var.cluster_name
   region               = var.region
   zone                 = var.zone
-  region_aws           = var.region_aws
-  aws_profile          = var.aws_profile
-  aws_credentials_file = var.aws_credentials_file
   allowed_ips          = var.allowed_ips
   agent_cidr           = var.agent_cidr
   nodes_sa             = module.iam.service_account
@@ -73,5 +70,6 @@ module "gke_cluster" {
   node_version         = var.node_version
   bastion_tag          = var.bastion_tag
   gke_node_tag         = var.gke_node_tag
+  ssh_public_key       = var.ssh_key
 }
 

--- a/terraform/env_types/gcp/gke/gke_create/main.tf
+++ b/terraform/env_types/gcp/gke/gke_create/main.tf
@@ -65,7 +65,6 @@ module "gke_cluster" {
   subnetwork           = module.vpc.subnet_name
   dns_zone_name        = var.dns_zone_name
   root_domain          = var.root_domain
-  secrets_storage      = var.secrets_storage
   k8s_version          = var.k8s_version
   node_version         = var.node_version
   bastion_tag          = var.bastion_tag

--- a/terraform/env_types/gcp/gke/gke_create/variables.tf
+++ b/terraform/env_types/gcp/gke/gke_create/variables.tf
@@ -30,10 +30,6 @@ variable "infra_cidr" {
   description = "GCP infra network CIDR"
 }
 
-variable "secrets_storage" {
-  description = "Cluster secrets storage"
-}
-
 variable "root_domain" {
   description = "Legion cluster root domain"
 }

--- a/terraform/env_types/gcp/gke/gke_create/variables.tf
+++ b/terraform/env_types/gcp/gke/gke_create/variables.tf
@@ -10,15 +10,6 @@ variable "cluster_name" {
   description = "Legion cluster name"
 }
 
-variable "aws_profile" {
-  description = "AWS profile name"
-}
-
-variable "aws_credentials_file" {
-  default     = "~/.aws/config"
-  description = "AWS credentials file location"
-}
-
 variable "zone" {
   default     = "us-east1-b"
   description = "Default zone"
@@ -27,11 +18,6 @@ variable "zone" {
 variable "region" {
   default     = "us-east1"
   description = "Region of resources"
-}
-
-variable "region_aws" {
-  default     = "us-east-2"
-  description = "Region of AWS resources"
 }
 
 variable "infra_vpc_name" {
@@ -124,6 +110,10 @@ variable "agent_cidr" {
 
 variable "dns_zone_name" {
   description = "Cluster root DNS zone name"
+}
+
+variable "ssh_key" {
+  description = "SSH public key for Legion cluster nodes and bastion host"
 }
 
 #############

--- a/terraform/env_types/gcp/gke/k8s_setup/main.tf
+++ b/terraform/env_types/gcp/gke/k8s_setup/main.tf
@@ -3,14 +3,12 @@
 ########################################################
 module "base_setup" {
   source               = "../../../../modules/k8s/base_setup"
-  aws_profile          = var.aws_profile
-  aws_credentials_file = var.aws_credentials_file
   zone                 = var.zone
   region               = var.region
-  region_aws           = var.region_aws
   project_id           = var.project_id
   cluster_name         = var.cluster_name
-  secrets_storage      = var.secrets_storage
+  tls_secret_key       = var.tls_key
+  tls_secret_crt       = var.tls_crt
 }
 
 module "nginx-ingress" {
@@ -27,16 +25,13 @@ module "nginx-ingress" {
 
 module "dashboard" {
   source               = "../../../../modules/k8s/dashboard"
-  aws_profile          = var.aws_profile
-  aws_credentials_file = var.aws_credentials_file
   zone                 = var.zone
   region               = var.region
-  region_aws           = var.region_aws
   project_id           = var.project_id
   cluster_name         = var.cluster_name
   root_domain          = var.root_domain
-  tls_secret_key       = module.base_setup.tls_secret_key
-  tls_secret_crt       = module.base_setup.tls_secret_crt
+  tls_secret_key       = var.tls_key
+  tls_secret_crt       = var.tls_crt
 }
 
 module "auth" {
@@ -55,11 +50,8 @@ module "auth" {
 
 module "monitoring" {
   source               = "../../../../modules/k8s/monitoring"
-  aws_profile          = var.aws_profile
-  aws_credentials_file = var.aws_credentials_file
   zone                 = var.zone
   region               = var.region
-  region_aws           = var.region_aws
   project_id           = var.project_id
   cluster_name         = var.cluster_name
   legion_helm_repo     = var.legion_helm_repo
@@ -70,8 +62,8 @@ module "monitoring" {
   grafana_pass         = var.grafana_pass
   docker_repo          = var.docker_repo
   monitoring_namespace = var.monitoring_namespace
-  tls_secret_key       = module.base_setup.tls_secret_key
-  tls_secret_crt       = module.base_setup.tls_secret_crt
+  tls_secret_key       = var.tls_key
+  tls_secret_crt       = var.tls_crt
 }
 
 module "istio" {
@@ -79,8 +71,8 @@ module "istio" {
   root_domain          = var.root_domain
   cluster_name         = var.cluster_name
   monitoring_namespace = var.monitoring_namespace
-  tls_secret_key       = module.base_setup.tls_secret_key
-  tls_secret_crt       = module.base_setup.tls_secret_crt
+  tls_secret_key       = var.tls_key
+  tls_secret_crt       = var.tls_crt
   legion_helm_repo     = var.legion_helm_repo
   legion_infra_version = var.legion_infra_version
 }

--- a/terraform/env_types/gcp/gke/k8s_setup/variables.tf
+++ b/terraform/env_types/gcp/gke/k8s_setup/variables.tf
@@ -23,24 +23,6 @@ variable "config_context_cluster" {
   description = "Legion cluster context name"
 }
 
-variable "region_aws" {
-  default     = "us-east-2"
-  description = "Region of AWS resources"
-}
-
-variable "aws_profile" {
-  description = "AWS profile name"
-}
-
-variable "aws_credentials_file" {
-  default     = "~/.aws/config"
-  description = "AWS credentials file location"
-}
-
-variable "secrets_storage" {
-  description = "Cluster secrets storage"
-}
-
 variable "cluster_name" {
   default     = "legion"
   description = "Legion cluster name"
@@ -68,6 +50,14 @@ variable "dns_zone_name" {
 
 variable "network_name" {
   description = "The VPC network to host the cluster in"
+}
+
+variable "tls_key" {
+  description = "TLS key for Legion cluster"
+}
+
+variable "tls_crt" {
+  description = "TLS certificate file for Legion cluster"
 }
 
 ########################

--- a/terraform/env_types/gcp/gke/legion/main.tf
+++ b/terraform/env_types/gcp/gke/legion/main.tf
@@ -5,13 +5,9 @@ module "legion" {
   source                      = "../../../../modules/legion"
   config_context_auth_info    = var.config_context_auth_info
   config_context_cluster      = var.config_context_cluster
-  aws_profile                 = var.aws_profile
-  aws_credentials_file        = var.aws_credentials_file
   zone                        = var.zone
   region                      = var.region
-  region_aws                  = var.region_aws
   project_id                  = var.project_id
-  secrets_storage             = var.secrets_storage
   legion_helm_repo            = var.legion_helm_repo
   root_domain                 = var.root_domain
   cluster_name                = var.cluster_name
@@ -33,4 +29,6 @@ module "legion" {
   model_authorization_enabled = true
   model_oidc_jwks_url         = "${var.keycloak_url}/auth/realms/${var.keycloak_realm}/protocol/openid-connect/certs"
   model_oidc_issuer           = "${var.keycloak_url}/auth/realms/${var.keycloak_realm}"
+  tls_secret_key              = var.tls_key
+  tls_secret_crt              = var.tls_crt
 }

--- a/terraform/env_types/gcp/gke/legion/variables.tf
+++ b/terraform/env_types/gcp/gke/legion/variables.tf
@@ -18,15 +18,6 @@ variable "config_context_cluster" {
   description = "Legion cluster context name"
 }
 
-variable "aws_profile" {
-  description = "AWS profile name"
-}
-
-variable "aws_credentials_file" {
-  default     = "~/.aws/config"
-  description = "AWS credentials file location"
-}
-
 variable "zone" {
   default     = "us-east1-b"
   description = "Default zone"
@@ -37,21 +28,20 @@ variable "region" {
   description = "Region of resources"
 }
 
-variable "region_aws" {
-  default     = "us-east-2"
-  description = "Region of AWS resources"
-}
-
-variable "secrets_storage" {
-  description = "Cluster secrets storage"
-}
-
 variable "legion_helm_repo" {
   description = "Legion helm repo"
 }
 
 variable "root_domain" {
   description = "Legion cluster root domain"
+}
+
+variable "tls_key" {
+  description = "TLS key for Legion cluster"
+}
+
+variable "tls_crt" {
+  description = "TLS certificate file for Legion cluster"
 }
 
 ##################

--- a/terraform/modules/gcp/gke_cluster/variables.tf
+++ b/terraform/modules/gcp/gke_cluster/variables.tf
@@ -91,6 +91,10 @@ variable "ssh_user" {
   description = "default ssh user"
 }
 
+variable "ssh_public_key" {
+  description = "SSH public key for Legion cluster nodes and bastion host"
+}
+
 variable "cluster_autoscaling_cpu_max_limit" {
   default     = 20
   description = "Maximum CPU limit for autoscaling if it is enabled."

--- a/terraform/modules/gcp/gke_cluster/variables.tf
+++ b/terraform/modules/gcp/gke_cluster/variables.tf
@@ -10,28 +10,12 @@ variable "cluster_name" {
   description = "Legion cluster name"
 }
 
-variable "aws_profile" {
-  description = "AWS profile name"
-}
-
-variable "aws_credentials_file" {
-  description = "AWS credentials file location"
-}
-
 variable "zone" {
   description = "Default zone"
 }
 
 variable "region" {
   description = "Region of resources"
-}
-
-variable "region_aws" {
-  description = "Region of AWS resources"
-}
-
-variable "secrets_storage" {
-  description = "Cluster secrets storage"
 }
 
 variable "root_domain" {

--- a/terraform/modules/k8s/base_setup/main.tf
+++ b/terraform/modules/k8s/base_setup/main.tf
@@ -5,25 +5,9 @@ provider "google" {
   project = var.project_id
 }
 
-provider "aws" {
-  version                 = "2.13"
-  region                  = var.region_aws
-  shared_credentials_file = var.aws_credentials_file
-  profile                 = var.aws_profile
-}
-
 ########################################################
 # K8S Cluster Setup
 ########################################################
-data "aws_s3_bucket_object" "tls-secret-key" {
-  bucket = var.secrets_storage
-  key    = "${var.cluster_name}/tls/${var.cluster_name}.key"
-}
-
-data "aws_s3_bucket_object" "tls-secret-crt" {
-  bucket = var.secrets_storage
-  key    = "${var.cluster_name}/tls/${var.cluster_name}.fullchain.crt"
-}
 
 # Install TLS cert as a secret
 resource "kubernetes_secret" "tls_default" {
@@ -33,8 +17,8 @@ resource "kubernetes_secret" "tls_default" {
     namespace = element(var.tls_namespaces, count.index)
   }
   data = {
-    "tls.key" = data.aws_s3_bucket_object.tls-secret-key.body
-    "tls.crt" = data.aws_s3_bucket_object.tls-secret-crt.body
+    "tls.key" = var.tls-secret-key
+    "tls.crt" = var.tls-secret-crt
   }
   type = "kubernetes.io/tls"
 }

--- a/terraform/modules/k8s/base_setup/main.tf
+++ b/terraform/modules/k8s/base_setup/main.tf
@@ -17,8 +17,8 @@ resource "kubernetes_secret" "tls_default" {
     namespace = element(var.tls_namespaces, count.index)
   }
   data = {
-    "tls.key" = var.tls-secret-key
-    "tls.crt" = var.tls-secret-crt
+    "tls.key" = var.tls_secret_key
+    "tls.crt" = var.tls_secret_crt
   }
   type = "kubernetes.io/tls"
 }

--- a/terraform/modules/k8s/base_setup/outputs.tf
+++ b/terraform/modules/k8s/base_setup/outputs.tf
@@ -1,8 +1,0 @@
-output "tls_secret_crt" {
-  value = data.aws_s3_bucket_object.tls-secret-crt.body
-}
-
-output "tls_secret_key" {
-  value = data.aws_s3_bucket_object.tls-secret-key.body
-}
-

--- a/terraform/modules/k8s/base_setup/variables.tf
+++ b/terraform/modules/k8s/base_setup/variables.tf
@@ -10,14 +10,6 @@ variable "cluster_name" {
   description = "Legion cluster name"
 }
 
-variable "aws_profile" {
-  description = "AWS profile name"
-}
-
-variable "aws_credentials_file" {
-  description = "AWS credentials file location"
-}
-
 variable "zone" {
   description = "Default zone"
 }
@@ -26,16 +18,15 @@ variable "region" {
   description = "Region of resources"
 }
 
-variable "region_aws" {
-  description = "Region of AWS resources"
-}
-
-variable "secrets_storage" {
-  description = "Cluster secrets storage"
-}
-
 variable "tls_namespaces" {
   default     = ["default", "kube-system"]
   description = "Default namespaces with TLS secret"
 }
 
+variable "tls_secret_crt" {
+  description = "Legion cluster TLS certificate"
+}
+
+variable "tls_secret_key" {
+  description = "Legion cluster TLS key"
+}

--- a/terraform/modules/k8s/dashboard/main.tf
+++ b/terraform/modules/k8s/dashboard/main.tf
@@ -10,13 +10,6 @@ provider "google" {
   project = var.project_id
 }
 
-provider "aws" {
-  version                 = "2.13"
-  region                  = var.region_aws
-  shared_credentials_file = var.aws_credentials_file
-  profile                 = var.aws_profile
-}
-
 ########################################################
 # Kubernetes Dashboard
 ########################################################

--- a/terraform/modules/k8s/dashboard/variables.tf
+++ b/terraform/modules/k8s/dashboard/variables.tf
@@ -10,24 +10,12 @@ variable "cluster_name" {
   description = "Legion cluster name"
 }
 
-variable "aws_profile" {
-  description = "AWS profile name"
-}
-
-variable "aws_credentials_file" {
-  description = "AWS credentials file location"
-}
-
 variable "zone" {
   description = "Default zone"
 }
 
 variable "region" {
   description = "Region of resources"
-}
-
-variable "region_aws" {
-  description = "Region of AWS resources"
 }
 
 variable "root_domain" {

--- a/terraform/modules/k8s/monitoring/variables.tf
+++ b/terraform/modules/k8s/monitoring/variables.tf
@@ -10,24 +10,12 @@ variable "cluster_name" {
   description = "Legion cluster name"
 }
 
-variable "aws_profile" {
-  description = "AWS profile name"
-}
-
-variable "aws_credentials_file" {
-  description = "AWS credentials file location"
-}
-
 variable "zone" {
   description = "Default zone"
 }
 
 variable "region" {
   description = "Region of resources"
-}
-
-variable "region_aws" {
-  description = "Region of AWS resources"
 }
 
 variable "legion_helm_repo" {

--- a/terraform/modules/legion/main.tf
+++ b/terraform/modules/legion/main.tf
@@ -23,8 +23,8 @@ resource "kubernetes_secret" "tls_legion" {
     namespace = var.legion_namespace
   }
   data = {
-    "tls.key" = var.tls-secret-key
-    "tls.crt" = var.tls-secret-crt
+    "tls.key" = var.tls_secret_key
+    "tls.crt" = var.tls_secret_crt
   }
   type = "kubernetes.io/tls"
 

--- a/terraform/modules/legion/main.tf
+++ b/terraform/modules/legion/main.tf
@@ -17,33 +17,14 @@ provider "google" {
   project = var.project_id
 }
 
-provider "aws" {
-  region                  = var.region_aws
-  shared_credentials_file = var.aws_credentials_file
-  profile                 = var.aws_profile
-}
-
-########################################################
-# TLS keys
-########################################################
-data "aws_s3_bucket_object" "tls-secret-key" {
-  bucket = var.secrets_storage
-  key    = "${var.cluster_name}/tls/${var.cluster_name}.key"
-}
-
-data "aws_s3_bucket_object" "tls-secret-crt" {
-  bucket = var.secrets_storage
-  key    = "${var.cluster_name}/tls/${var.cluster_name}.fullchain.crt"
-}
-
 resource "kubernetes_secret" "tls_legion" {
   metadata {
     name      = "${var.cluster_name}-tls"
     namespace = var.legion_namespace
   }
   data = {
-    "tls.key" = data.aws_s3_bucket_object.tls-secret-key.body
-    "tls.crt" = data.aws_s3_bucket_object.tls-secret-crt.body
+    "tls.key" = var.tls-secret-key
+    "tls.crt" = var.tls-secret-crt
   }
   type = "kubernetes.io/tls"
 

--- a/terraform/modules/legion/variables.tf
+++ b/terraform/modules/legion/variables.tf
@@ -18,14 +18,6 @@ variable "config_context_cluster" {
   description = "Legion cluster context name"
 }
 
-variable "aws_profile" {
-  description = "AWS profile name"
-}
-
-variable "aws_credentials_file" {
-  description = "AWS credentials file location"
-}
-
 variable "zone" {
   default     = "us-east1-b"
   description = "Default zone"
@@ -36,21 +28,20 @@ variable "region" {
   description = "Region of resources"
 }
 
-variable "region_aws" {
-  default     = "us-east-2"
-  description = "Region of AWS resources"
-}
-
-variable "secrets_storage" {
-  description = "Cluster secrets storage"
-}
-
 variable "legion_helm_repo" {
   description = "Legion helm repo"
 }
 
 variable "root_domain" {
   description = "Legion cluster root domain"
+}
+
+variable "tls_secret_crt" {
+  description = "Legion cluster TLS certificate"
+}
+
+variable "tls_secret_key" {
+  description = "Legion cluster TLS key"
 }
 
 ##################

--- a/tools/hiera_exporter
+++ b/tools/hiera_exporter
@@ -70,7 +70,7 @@ def hiera_get(config, key_name, env, cloud):
     Read hiera data
     """
 
-    hiera_command = [HIERA_BINARY, '-a', '--config', config, key_name, "environment={}".format(env),
+    hiera_command = [HIERA_BINARY, '-a', '-f', 'json', '--config', config, key_name, "environment={}".format(env),
                      "cloud={}".format(cloud)]
     log.debug(hiera_command)
 

--- a/vars_template.yaml
+++ b/vars_template.yaml
@@ -4,15 +4,10 @@
 # set GOOGLE_CREDENTIALS=/path/to/creds/.json or enable the property below
 # gcp_credentials:            # path to /gpc/credential/file.json
 cluster_name: str               # Common gcp cluster name
-region: str                     # GCP region for environment regional resources
-zone: str                       # GCP cluster zone where the cluster is deployed
 root_domain: str                # Root domain of the cluster
 config_context_auth_info: str   # GKE cluster auth info
 config_context_cluster: str     # GKE cluster context
-aws_vpc_id: str                 # AWS peered VPC ID
 network_name: str               # GCP VPC Network name
-bastion_tag: str                # Bastion host network tag
-gke_node_tag: str               # GKE cluster node's network tag
 infra_cidr: str                 # Core infrastructure resources CIDR
 pods_cidr: str                  # Cluster PODs CIDR
 service_cidr: str               # Cluster Services CIDR
@@ -23,14 +18,26 @@ tfstate_bucket: str             # GCS Bucket for cluster TF state
 ssh_key: str                    # SSH public key for cluster nodes and bastion
 tls_key: str                    # TLS private key for Legion cluster
 tls_crt: str                    # TLS certificates chain for Legion cluster
+allowed_ips: list               # List of WAN IPs to whitelist on cluster
 
 ########################################################
 # GKE module
 ########################################################
+dns_zone_name: str              # Cloud DNS zone name for the cluster
+aws_profile: str                # AWS profile
+aws_vpc_id: str                 # AWS peered VPC ID
+aws_sg: str                     # AWS Security group ID to grant access from nodes at GCP (for Core components access)
+aws_cidr: str                   # AWS CIDR for VPC peering setup
+aws_route_table_id: str         # AWS route table ID for VPC peering setup
+region: str                     # GCP region for environment regional resources
+zone: str                       # GCP cluster zone where the cluster is deployed
+project_id: str                 # GCP project ID
+bastion_tag: str                # Bastion host network tag
+gke_node_tag: str               # GKE cluster node's network tag
+gcp_cidr: str                   # CIDR for GKE cluster nodes
 location: str                   # GKE cluster zone
 node_locations: list            # GKE cluster zones to place nodes in
 initial_node_count: str         # GKE init node pool node count
-dns_zone_name: str              # Cloud DNS zone name for the cluster
 
 ########################################################
 # Common Legion variables
@@ -48,16 +55,6 @@ github_org_name: str            # GitHub Organization name for cluster access
 legion_version: str             # Legion version to be deployed
 mlflow_toolchain_version: str   # Mlflow toolchain version to be deployed
 legion_data_bucket: str         # GCP Storage bucket for Legion data
-
-########################################################
-# Common variables
-########################################################
-project_id: str                 # GCP project ID
-allowed_ips: list               # List of WAN IPs to whitelist on cluster
-gcp_cidr: str                   # CIDR for cluster nodes
-aws_sg: str                     # AWS Security group ID to grant access from nodes at GCP (for Core components access)
-aws_cidr: str                   # AWS CIDR for VPC peering setup
-aws_route_table_id: str         # AWS route table ID for VPC peering setup
 
 ########################################################
 # K8S base components

--- a/vars_template.yaml
+++ b/vars_template.yaml
@@ -7,7 +7,6 @@ cluster_name: str               # Common gcp cluster name
 region: str                     # GCP region for environment regional resources
 zone: str                       # GCP cluster zone where the cluster is deployed
 root_domain: str                # Root domain of the cluster
-aws_profile: str                # AWS boto profile
 config_context_auth_info: str   # GKE cluster auth info
 config_context_cluster: str     # GKE cluster context
 aws_vpc_id: str                 # AWS peered VPC ID
@@ -21,6 +20,9 @@ cloud_type: str                 # Target hosting cloud
 k8s_version: str                # Kubernetes master version
 node_version: str               # Kubernetes node version
 tfstate_bucket: str             # GCS Bucket for cluster TF state
+ssh_key: str                    # SSH public key for cluster nodes and bastion
+tls_key: str                    # TLS private key for Legion cluster
+tls_crt: str                    # TLS certificates chain for Legion cluster
 
 ########################################################
 # GKE module
@@ -52,7 +54,6 @@ legion_data_bucket: str         # GCP Storage bucket for Legion data
 ########################################################
 project_id: str                 # GCP project ID
 allowed_ips: list               # List of WAN IPs to whitelist on cluster
-secrets_storage: str            # AWS S3 bucket with sensitive data such as TLS certs and cluster SSH keys
 gcp_cidr: str                   # CIDR for cluster nodes
 aws_sg: str                     # AWS Security group ID to grant access from nodes at GCP (for Core components access)
 aws_cidr: str                   # AWS CIDR for VPC peering setup


### PR DESCRIPTION
- AWS provider removed from all terraform modules along with the variables necessary for it
- Jenkins pipelines and cluster profile template are corrected according to these changes
- TLS and SSH data are moved to the cluster profile (see the corresponding merge request in the `legion-profiles` repository)
- slightly updated readme

Fixes #47.
