### PR TITLE
[#1031] Azure Storage SAS Token for fluend

### DIFF
--- a/terraform/env_types/azure/aks/legion/main.tf
+++ b/terraform/env_types/azure/aks/legion/main.tf
@@ -41,7 +41,6 @@ module "legion" {
   legion_data_bucket = var.legion_data_bucket
 
   azure_storage_account    = module.legion_prereqs.storage_account
-  azure_storage_access_key = module.legion_prereqs.storage_access_key
 
   model_docker_user        = module.legion_prereqs.model_docker_user
   model_docker_repo        = module.legion_prereqs.model_docker_repo

--- a/terraform/modules/legion/main.tf
+++ b/terraform/modules/legion/main.tf
@@ -98,8 +98,8 @@ data "template_file" "legion_values" {
     legion_collector_sa       = var.legion_collector_sa
     legion_collector_iam_role = var.legion_collector_iam_role
 
-    azure_storage_account    = var.azure_storage_account
-    azure_storage_access_key = var.azure_storage_access_key
+    azure_storage_account   = var.azure_storage_account
+    azure_storage_sas_token = "?${replace(var.model_output_secret, "/.+?\\?/", "")}"
 
     model_authorization_enabled = var.model_authorization_enabled
     model_oidc_jwks_url         = var.model_oidc_jwks_url
@@ -118,7 +118,7 @@ data "template_file" "legion_values" {
     model_output_region      = var.model_output_region
     model_output_secret      = var.model_output_secret
     model_output_secret_key  = var.model_output_secret_key
-    model_output_description = "Storage for trainined artifacts"
+    model_output_description = "Storage for trained artifacts"
     model_output_web_ui_link = var.model_output_web_ui_link
 
     model_docker_user        = var.model_docker_user

--- a/terraform/modules/legion/templates/legion.yaml
+++ b/terraform/modules/legion/templates/legion.yaml
@@ -30,10 +30,10 @@ feedback:
 %{ if cloud_type == "azure" ~}
     target: "azureblob"
     azureblob:
-      authorization: "accesskey"
+      authorization: "sastoken"
       bucket: "${legion_data_bucket}"
       AzureStorageAccount: "${azure_storage_account}"
-      AzureStorageAccessKey: "${azure_storage_access_key}"
+      AzureStorageSasToken: "${azure_storage_sas_token}"
 %{ endif ~}
 
 edi:

--- a/terraform/modules/legion/variables.tf
+++ b/terraform/modules/legion/variables.tf
@@ -30,8 +30,6 @@ variable "legion_collector_sa" { default = "" }
 
 variable "azure_storage_account" { default = "" }
 
-variable "azure_storage_access_key" { default = "" }
-
 ##################
 # Common
 ##################

--- a/terraform/modules/legion_aks/main.tf
+++ b/terraform/modules/legion_aks/main.tf
@@ -86,7 +86,7 @@ resource "null_resource" "secure_kube_api" {
   }
   provisioner "local-exec" {
     when    = "destroy"
-    command = "az aks update --resource-group ${var.resource_group} --name ${var.cluster_name} --api-server-authorized-ip-ranges \"\""
+    command = "az extension add --name aks-preview && az aks update --resource-group ${var.resource_group} --name ${var.cluster_name} --api-server-authorized-ip-ranges \"\""
     interpreter = ["timeout", "300", "bash", "-c"]
   }
 
@@ -129,7 +129,7 @@ data "azurerm_storage_account_sas" "legion" {
   }
 
   resource_types {
-    service   = false
+    service   = true
     container = true
     object    = true
   }

--- a/terraform/modules/legion_aks/output.tf
+++ b/terraform/modules/legion_aks/output.tf
@@ -23,7 +23,6 @@ output "model_output_bucket" {
 }
 
 output "model_output_secret" {
-  #value    = data.azurerm_storage_account.legion_storage.primary_access_key
   value     = "${azurerm_storage_account.legion_data.primary_blob_endpoint}${data.azurerm_storage_account_sas.legion.sas}"
   sensitive = true
 }
@@ -38,9 +37,4 @@ output "feedback_storage_link" {
 
 output "storage_account" {
   value = azurerm_storage_account.legion_data.name
-}
-
-output "storage_access_key" {
-  value     = azurerm_storage_account.legion_data.primary_access_key
-  sensitive = true
 }


### PR DESCRIPTION
Auth in Azure Blob storage for Feedback (fluend plugin) switched to using of SAS token instead of Azure Storage Access key with full access to Storage Account.

This PR closes [#1031](https://github.com/legion-platform/legion/issues/1031) and should be merged after corresponding [PR in legion repository](https://github.com/legion-platform/legion/pull/1050).