### PR TITLE
[#1052] Fix the docker repository URL in case of Azure and AWS

### DIFF
--- a/pipelines/legionPipeline.groovy
+++ b/pipelines/legionPipeline.groovy
@@ -279,6 +279,14 @@ def runRobotTests(tags="", cloudCredsSecret, dockerArgPrefix) {
                     docker.image("${env.param_docker_repo}/legion-pipeline-agent:${env.param_legion_version}").inside(dockerArgs) {
                         stage('Run Robot tests') {
                             dir("${WORKSPACE}"){
+                                def docker_repo = ""
+
+                                if (env.param_cloud_provider == "gcp") {
+                                    docker_repo = env.param_docker_repo
+                                } else {
+                                    docker_repo = sh(script: "jq '.docker_repo' ${env.clusterProfile}", returnStdout: true).trim()
+                                }
+
                                 def tags_list = tags.toString().trim().split(',')
                                 def robot_tags = ["-e disable"]
 
@@ -300,7 +308,7 @@ def runRobotTests(tags="", cloudCredsSecret, dockerArgPrefix) {
                                     make CLUSTER_PROFILE=${env.clusterProfile} \
                                          CLUSTER_NAME=${env.param_cluster_name} \
                                          CLOUD_PROVIDER=${env.param_cloud_provider} \
-                                         DOCKER_REGISTRY=${env.param_docker_repo} \
+                                         DOCKER_REGISTRY=${docker_repo} \
                                          LEGION_VERSION=${env.param_legion_version} setup-e2e-robot
 
                                     ROBOT_PARAMS=(CLUSTER_PROFILE=${env.clusterProfile} \

--- a/terraform/modules/legion_aks/main.tf
+++ b/terraform/modules/legion_aks/main.tf
@@ -89,7 +89,6 @@ resource "null_resource" "secure_kube_api" {
     command = "az extension add --name aks-preview && az aks update --resource-group ${var.resource_group} --name ${var.cluster_name} --api-server-authorized-ip-ranges \"\""
     interpreter = ["timeout", "300", "bash", "-c"]
   }
-
 }
 
 ########################################################
@@ -114,7 +113,8 @@ resource "azurerm_storage_account" "legion_data" {
     )
   }
 
-  tags = local.storage_tags
+  tags       = local.storage_tags
+  depends_on = [null_resource.secure_kube_api]
 }
 
 data "azurerm_storage_account_sas" "legion" {


### PR DESCRIPTION
Before these changes, we passed the docker URL parameter from
Jenkins's job into the setup robot tests script. This URL is used for
deploying pods inside k8s for testing purposes. It follows that in the
case of AWS and Azure, we must pass the docker URL from hiera because
the Docker URL in hiera doesn't contain `-local` suffix.